### PR TITLE
no age shaming

### DIFF
--- a/MediaPushPlugin/src/main/resources/media-push-extension/manifest.json
+++ b/MediaPushPlugin/src/main/resources/media-push-extension/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Ant Media Media Push Extension Manifest v3",
 	"version": "1.0.0",
 	"manifest_version": 3,
-	"minimum_chrome_version": "116",
+	"minimum_chrome_version": "1",
 	"action": {
 		"default_icon": "icons/not-broadcasting.png"
 	},


### PR DESCRIPTION
no age shamingif you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)